### PR TITLE
Command to generate images for molecules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,9 @@ venv
 # Exclude idea (should be in global gitignore usually)
 .idea
 
-# Exlude .env file
+# Exclude .env file
 .env
+
+# Exclude static and media files
+images
+static

--- a/molecule_admin/management/commands/create_images.py
+++ b/molecule_admin/management/commands/create_images.py
@@ -1,0 +1,37 @@
+from os.path import exists
+
+from django.core.exceptions import SuspiciousFileOperation
+from django.core.management.base import BaseCommand, CommandError
+from django.utils.text import get_valid_filename
+from rdkit import Chem
+from rdkit.Chem import Draw
+
+from molecule_admin.models import Molecule
+
+
+class Command(BaseCommand):
+    help = "Create images for molecules."
+
+    def add_arguments(self, parser):
+        parser.add_argument('file_path', action='store', type=str)
+
+    def handle(self, *args, **options):
+        output_dir = options['file_path']
+        if not exists(output_dir):
+            raise CommandError(f"File: {output_dir} does not exist.")
+
+        molecules = Molecule.objects.all()
+        for molecule in molecules:
+            m = Chem.MolFromSmiles(molecule.smiles)
+            try:
+                file_name = f"{get_valid_filename(molecule.name)}.png"
+            except SuspiciousFileOperation:
+                file_name = f"{molecule.id}.png"
+            try:
+                Draw.MolToFile(m, f'{output_dir}/'
+                                  f'{file_name}')
+                molecule.image = file_name
+                molecule.save()
+                self.stdout.write(f"Created image for {molecule.name}")
+            except (FileNotFoundError, ValueError):
+                self.stderr.write(f"Couldn't create image for {molecule.name}")

--- a/molecule_admin/templates/molecules/molecule_list.html
+++ b/molecule_admin/templates/molecules/molecule_list.html
@@ -62,8 +62,8 @@
             {% for molecule in object_list %}
             <div class="col-sm-3 ps-0 pe-0">
                 <div class="card text-center h-100">
-                    <img src="" class="card-img-top" alt="img">
-                    <h5 class="card-title">{{ molecule.name}}</h5>
+                    <img src="{{ molecule.image.url }}" class="card-img-top" alt="img">
+                    <h5 class="card-title">{{ molecule.name|safe}}</h5>
                     <div class="card-body">
                         <div>
                             {{ molecule.inchi_key}}
@@ -93,8 +93,7 @@
         {% endif %}
 
         <li class="page-item active"><a class="page-link" href="#">
-            Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages
-            }}</a>
+            Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</a>
         </li>
 
 

--- a/molecule_project/settings.py
+++ b/molecule_project/settings.py
@@ -13,6 +13,7 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 from pathlib import Path
 
 from decouple import config
+import os.path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -119,6 +120,10 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/4.0/howto/static-files/
 
 STATIC_URL = 'static/'
+STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+
+MEDIA_URL = 'images/'
+MEDIA_ROOT = os.path.join(BASE_DIR, 'images')
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.0/ref/settings/#default-auto-field

--- a/molecule_project/urls.py
+++ b/molecule_project/urls.py
@@ -15,10 +15,13 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from django.conf import settings
+from django.conf.urls.static import static
 
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include("molecule_admin.urls")),
     path('accounts/', include('django.contrib.auth.urls')),
-]
+] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT) \
+              + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Django==4.0.4
 Pillow==9.1.1
+rdkit-pypi==2022.3.2.1


### PR DESCRIPTION
- added media root and media paths to urls
- command creates images for molecules using rdkit package
- exclude static and media files in .gitignore
- url for image in molecule_list template
- added rdkit to requirements - dependency for image creation